### PR TITLE
chore(deps): upgrade Qiscus Chat SDK to 2.2.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This sample demonstrates how to build a full-featured chat application using the
 
 **Built with:**
 - ✅ Flutter 3.x
-- ✅ Qiscus Chat SDK 2.0.11
+- ✅ [Qiscus Chat SDK 2.2.1](https://pub.dev/packages/qiscus_chat_sdk)
 - ✅ Provider for state management
 - ✅ Material 3 design
 - ✅ Firebase integration
@@ -224,7 +224,7 @@ context.watch<ChatProvider>().messages
 flutter: sdk: flutter
 
 # Qiscus Chat SDK
-qiscus_chat_sdk: ^2.0.11
+qiscus_chat_sdk: ^2.2.1
 
 # State Management
 provider: ^6.0.5

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -667,9 +667,10 @@ packages:
   qiscus_chat_sdk:
     dependency: "direct main"
     description:
-      path: "../qiscus-chat-sdk-flutter"
-      relative: true
-    source: path
+      name: qiscus_chat_sdk
+      sha256: "8cb606e6d467940d10d1e610bd9f83a05fa348ae7279f8a7ac22877cdf8c7c0a"
+      url: "https://pub.dev"
+    source: hosted
     version: "2.2.1"
   rxdart:
     dependency: transitive

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -43,9 +43,9 @@ dependencies:
   visibility_detector: ^0.4.0+2
   equatable: ^2.0.5
 
-dependency_overrides:
-  qiscus_chat_sdk:
-    path: ../qiscus-chat-sdk-flutter
+# dependency_overrides:
+#   qiscus_chat_sdk:
+#     path: ../qiscus-chat-sdk-flutter
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
- Updated Qiscus Chat SDK dependency from 2.0.11 to 2.2.1 in pubspec.yaml
- Added hyperlink to SDK package in README.md for better documentation
- Removed local dependency override for qiscus_chat_sdk that was using local path
- Updated SDK version reference in "Built with" section of README.md